### PR TITLE
Update READMEs for Assessments with Feedback

### DIFF
--- a/challenge1/README.md
+++ b/challenge1/README.md
@@ -78,6 +78,21 @@ It is after all better to be able to read your HTML and not have to trudge throu
 
 This does however mean a Div is still present as that `div` is an actual `division` of logic that I decided on to make a spacer.
 
+## Feedback
+
+After the interview there was some feedback discussed about the Static Page Assessment and is as follows:
+
+1. The image should resize dynamically  
+This was a misunderstanding as it is meant to not take up more than a certain amount of height until a certain threshold is passed so as to prevent unnessisary scrolling by the client. This could have been better documented in the README
+
+2. There was an H4 tag closed with an H3 tag  
+This was an error from a find and replace macro that was supposed to change the H3 to an H4, however it missed the closing tag. This is something my IDE(VSCode) does not support(highlighting of mismatched tags in pure HTML documents). This could probably be fixed by a plugin. I'll have to look for one.
+
+3. The modification to the logo to achieve a proper logo was appreciated
+
+4. The Arrow Fonts were actually images in Photoshop, it just so happens that they are almost 1:1 pixel perfect to Font Awesome's arrows  
+A fun discovery
+
 ## Hilton Properties and Licenses
 
 Hilton provided assets list:

--- a/challenge2/README.md
+++ b/challenge2/README.md
@@ -57,6 +57,17 @@ In all reality if this were part of a larger application it would then want to b
 
 - If loaded state cannot be parsed recreate state and error log reason why
 
+## Feedback
+
+1. There are other ways to load the state from disc into the class. Why did you choose the constructor? Why not the Component Did Mount life cycle?  
+If a component is not mounted the life cycle event never fires(same with component will mount), and sometimes you want to expose methods to query the state before that life cycle is fired. As such waiting until then can be too late to detect state before mounting. While a default state is possible, this means that there is a change between first query and actual mount, so reliability was a concern
+
+2. The constructor is somewhat long. The logic to confirm and build the state could have been moved out of the constructor  
+At 33 lines this is a valid concern and instead this logic should have been in a helper function that could have been expose so that other modules could confirm the state as well. This would normally lead to an issue and then Pull Request. It would have been a good example of a Static Method on the class, same with a default state building method.
+
+3. Some of the tests directly interacted with State. While many of the tests were good, why did these ones interact with the state instead of focusing on the DOM?  
+Because the DOM should be decided from the State I thought it would be a good place to test the mirroring that DOM updates State correctly, however this strictly ties the State into the test and if implimentation changes would quickly break that test. This would normally lead to an issue and then Pull Request to update the test. It is extremely helpful critique of how little things in testing can sometimes go unnoticed.
+
 ## Running the application
 
 Please read either [the short readme](#the-short-readme) or the [Create React App README](#create-react-app-readme)


### PR DESCRIPTION
There was feedback that this Assessment would be a good example to show that the assessment might need some clarification since it seems the mention of a footer makes it confusing as to where the navigation should actually live. This however is left out of the README updates.