### PR TITLE
FIX: tests relying on state structure, missing test for formState() creator static method

### DIFF
--- a/challenge2/src/DynamicForm.class/DynamicForm.test.tsx
+++ b/challenge2/src/DynamicForm.class/DynamicForm.test.tsx
@@ -29,6 +29,11 @@ describe(
       };
       mountedAPP = undefined;
     });
+
+    it('exposes a state helper to get a default state and construct it with a number of rooms', () => {
+      expect(DynamicForm.formState).toBeInstanceOf(Function);
+      expect(DynamicForm.length).toBe(1);
+    })
     
     it('always renders a form', () => {
       expect(APP().find('form').length).toBe(1);

--- a/challenge2/src/DynamicForm.class/DynamicForm.test.tsx
+++ b/challenge2/src/DynamicForm.class/DynamicForm.test.tsx
@@ -58,7 +58,7 @@ describe(
           }
         }));
         props.rooms = 2;
-        expect(APP().state('rooms').room1.toggle).toBe(false);
+        expect(JSON.stringify(APP().state())).toBe(window.localStorage.getItem('DynamicForm.state'));
         window.localStorage.clear();
       });
 
@@ -67,7 +67,7 @@ describe(
         props.rooms = 2;
         let consolerror = console.error;
         console.error = jest.fn();
-        expect(APP().state('rooms').room1.toggle).toBe(true);
+        expect(JSON.stringify(APP().state())).toBe(JSON.stringify(DynamicForm.formState(2)));
         window.localStorage.clear();
         console.error = consolerror;
       });
@@ -103,8 +103,7 @@ describe(
           }
         }));
         props.rooms = 2;
-        const rooms = APP().state('rooms');
-        expect(rooms.room0 != null && rooms.room1 != null && rooms.room4 == null).toBe(true);
+        expect(JSON.stringify(APP().state())).toBe(JSON.stringify(DynamicForm.formState(2)));
         window.localStorage.clear();
       });
 
@@ -120,8 +119,7 @@ describe(
           }
         }));
         props.rooms = 1;
-        const rooms = APP().state('rooms');
-        expect(rooms.room0 != null && rooms.room4 == null).toBe(true);
+        expect(JSON.stringify(APP().state())).toBe(JSON.stringify(DynamicForm.formState(1)));
         window.localStorage.clear();
       });
 
@@ -158,20 +156,20 @@ describe(
       describe('The checkboxes', () =>{
         it('does not let you change the `Room 1` checkbox even if you enable it or manually fire a change event', () => {
           APP().find({ type: 'checkbox' }).first().simulate('change', { target: {checked : false}});
-          expect(APP().state('rooms').room0.selected).toBe(true);
+          expect(APP().find({ type: 'checkbox' }).first().prop('checked')).toBe(true);
         });
 
         it('updates state when you click on a checkbox other tham `Room 1`', () => {
           APP().find({ type: 'checkbox' }).last().simulate('change', { target: {checked : true}});
-          expect(APP().state('rooms').room3.selected).toBe(true);
+          expect(APP().find({ type: 'checkbox' }).last().prop('checked')).toBe(true);
         });
   
         it('selects the room if you click on the checkbox for the room and will set any lower rooms selected as well', () => {
           APP().find({ type: 'checkbox' }).at(2).simulate('change', { target: {checked : true}});
           expect(
-            APP().state('rooms').room3.selected == false &&
-            APP().state('rooms').room2.selected == true &&
-            APP().state('rooms').room1.selected == true
+            APP().find({ type: 'checkbox' }).last().prop('checked') == false &&
+            APP().find({ type: 'checkbox' }).at(2).prop('checked') == true &&
+            APP().find({ type: 'checkbox' }).at(1).prop('checked') == true
             ).toBe(true);
         });
 
@@ -179,9 +177,9 @@ describe(
           APP().find({ type: 'checkbox' }).last().simulate('change', { target: {checked : true}});
           APP().find({ type: 'checkbox' }).at(1).simulate('change', { target: {checked : false}});
           expect(
-            APP().state('rooms').room3.selected == false &&
-            APP().state('rooms').room2.selected == false &&
-            APP().state('rooms').room1.selected == false
+            APP().find({ type: 'checkbox' }).last().prop('checked') == false &&
+            APP().find({ type: 'checkbox' }).at(2).prop('checked') == false &&
+            APP().find({ type: 'checkbox' }).at(1).prop('checked') == false
             ).toBe(true);
         });
       });


### PR DESCRIPTION
Resolves #12 

[x] Adds missing test case for Static Class Method `formState()` that is used to construct a state with a number of rooms by checking it's length, and that it is a function(actual functionality is defined in the state fallback and comparison testing)

[x] Removes reliance on checking state variables. This is not an integration test, and as such should only compare it in HOW that state gets made, and HOW that state getting made would look in a comparable method